### PR TITLE
rootURL for JENKINS-12346 and workspace tmpfile cleanup

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/managedscripts/ScriptBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/managedscripts/ScriptBuildStep.java
@@ -163,15 +163,26 @@ public class ScriptBuildStep extends Builder {
 			FilePath source = new FilePath(tempFile);
 			FilePath dest = new FilePath(Computer.currentComputer().getChannel(), workingDir + "/" + tempFile.getName());
 
-			log.log(Level.FINE, "Copying temporary file to " + Computer.currentComputer().getHostName() + ":" + workingDir + "/" + tempFile.getName());
-			source.copyTo(dest);
 
-			/*
-			 * Execute command remotely
-			 */
-			listener.getLogger().println("Executing temp file '" + tempFile.getPath() + "'");
-			int r = lastBuiltLauncher.launch().cmds(args).envs(env).stderr(listener.getLogger()).stdout(listener.getLogger()).pwd(workingDir).join();
-			returnValue = (r == 0);
+			try {
+				log.log(Level.FINE, "Copying temporary file to " + Computer.currentComputer().getHostName() + ":" + workingDir + "/" + tempFile.getName());
+				source.copyTo(dest);
+				/*
+				 * Execute command remotely
+				 */
+				listener.getLogger().println("Executing temp file '" + tempFile.getPath() + "'");
+				int r = lastBuiltLauncher.launch().cmds(args).envs(env).stderr(listener.getLogger()).stdout(listener.getLogger()).pwd(workingDir).join();
+				returnValue = (r == 0);
+			} finally {
+
+				try {
+					dest.delete();
+				} catch (Exception e) {
+					e.printStackTrace(listener.fatalError("Cannot remove temporary script file '" + dest.getName() + "'"));
+					returnValue = false;
+				}
+			}
+
 
 		} catch (IOException e) {
 			Util.displayIOException(e, listener);

--- a/src/main/resources/org/jenkinsci/plugins/managedscripts/ScriptBuildStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/managedscripts/ScriptBuildStep/config.jelly
@@ -1,7 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
 	<st:once>
-		<script type="text/javascript" src="/plugin/managed-scripts/js/managed-scripts.js" />
+		<script type="text/javascript" src="${rootURL}/plugin/managed-scripts/js/managed-scripts.js" />
 	</st:once>
 	<j:choose>
 		<j:when test="${empty(descriptor.availableBuildTemplates)}">


### PR DESCRIPTION
add ${rootURL} for prefixed jenkins

add a delete() for tmpfiles that were being left in the workspace like:

build_step_template1119769465643262200.sh
