### PR TITLE
Specify JDK8 in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ platforms['windows'] = {
     node('windows') {
         checkout scm
         withEnv([
-            "JAVA_HOME=${tool 'jdk7'}",
+            "JAVA_HOME=${tool 'jdk8'}",
             "PATH+MAVEN=${tool 'mvn'}/bin",
         ]) {
             bat mavenCommand
@@ -22,7 +22,7 @@ platforms['linux'] = {
     node('linux') {
         checkout scm
         withEnv([
-            "JAVA_HOME=${tool 'jdk7'}",
+            "JAVA_HOME=${tool 'jdk8'}",
             "PATH+MAVEN=${tool 'mvn'}/bin",
         ]) {
             sh mavenCommand

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5</version>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.4</version>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
The current target Jenkins version in the pom.xml supports it

Also, other pull requests will not successfully build on the Jenkins CI server while building with JDK7