### PR TITLE
Update the URL/documentation entry in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <jenkins.version>2.204</jenkins.version>
     </properties>
 
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Managed+Script+Plugin</url>
+    <url>https://github.com/jenkinsci/managed-scripts-plugin</url>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/managed-scripts-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/managed-scripts-plugin.git</developerConnection>


### PR DESCRIPTION
As per https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/, this should be the one missing piece preventing the plugin page from using the updated documentation in the GitHub repo.

Unfortunately it will require another release before the change is visible on the plugins page.