### PR TITLE
Hacktoberfest - Update base jenkins version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <java.level>8</java.level>
-        <jenkins.version>2.277</jenkins.version>
+        <jenkins.version>2.319.3</jenkins.version>
     </properties>
 
     <url>https://github.com/jenkinsci/managed-scripts-plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.13</version>
+        <version>4.48</version>
     </parent>
 
     <groupId>org.jenkinsci.plugins</groupId>


### PR DESCRIPTION
Tested with Jenkins version 2.346.3, 2.332.4, 2.319.3, 2.303.3
worked with 2.319.3 and 2.303.3, so updated with 2.319.3

and removed line (<java.level>8</java.level>) in properties since maven was giving this warning :
**[WARNING] Ignoring deprecated java.level property. This property should be removed from your plugin's POM. In the future, this warning will be changed to an error and will break the build.** 


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did